### PR TITLE
Set subscription attributes on subscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ subscribe or unsubscribe the functions manually (outside of a deploy or remove
 command), you can use `sls subscribeExternalSNS` or
 `sls unsubscribeExternalSNS`.
 
-**NOTE:** This plugin requires the AWS SDK (`require('aws-sdk')`), but does not
-list it as a dependency. This allows you to provide the dependency your own
-way, making sure not to bundle the SDK and all its dependencies with your
-function code.
-
 
 ## How do I contribute?
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ subscribe or unsubscribe the functions manually (outside of a deploy or remove
 command), you can use `serverless subscribeExternalSNS` or
 `serverless unsubscribeExternalSNS`.
 
-You can also set subscription attributes outlined [here](http://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html)
+You can also set subscription attributes outlined [here](http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#set-sub-attributes-delivery-policy-json)
 
 ```
 functions:

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ functions:
 By doing that, the `deploy` and `remove` commands in SLS will now subscribe and
 unsubscribe your function to or from the specified topic. If you would like to
 subscribe or unsubscribe the functions manually (outside of a deploy or remove
-command), you can use `sls subscribeExternalSNS` or
-`sls unsubscribeExternalSNS`.
+command), you can use `serverless subscribeExternalSNS` or
+`serverless unsubscribeExternalSNS`.
 
 
 ## How do I contribute?

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ subscribe or unsubscribe the functions manually (outside of a deploy or remove
 command), you can use `serverless subscribeExternalSNS` or
 `serverless unsubscribeExternalSNS`.
 
+You can also set subscription attributes outlined [here](http://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html)
+
+```
+functions:
+   doSomething:
+      name: ${self:service}-${self:provider.stage}-doSomething
+      handler: src/DoSomething.handler
+      events:
+         - externalSNS:
+            topic: 'some-topic-name'
+            DeliveryPolicy:
+                minDelayTarget: 20
+                maxDelayTarget: 60
+                numRetries: 10
+```
 
 ## How do I contribute?
 

--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
   "homepage": "https://github.com/silvermine/serverless-plugin-external-sns-events#readme",
   "dependencies": {
     "class.extend": "0.9.2",
-    "q": "1.4.1",
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "aws-sdk": "2.6.9",
     "coveralls": "2.11.12",
     "eslint": "3.3.1",
     "eslint-config-silvermine": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "istanbul": "0.4.4",
     "mocha": "3.0.2",
     "mocha-lcov-reporter": "1.2.0",
-    "sinon": "1.17.5"
+    "sinon": "1.17.5",
+    "bluebird": "^3.4.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ module.exports = Class.extend({
             FunctionName: { 'Fn::GetAtt': [ fnRef, 'Arn' ] },
             Action: 'lambda:InvokeFunction',
             Principal: 'sns.amazonaws.com',
+            SourceArn: { 'Fn::Join': [ ':', [ 'arn:aws:sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, topicName ] ] }
          },
       };
 

--- a/src/index.js
+++ b/src/index.js
@@ -67,9 +67,10 @@ module.exports = Class.extend({
       var self = this;
 
       if (this._opts.noDeploy) {
-         return this._serverless.cli.log(
+         this._serverless.cli.log(
             'Not subscribing ' + fnDef.name + ' to ' + topicName + ' because of the noDeploy flag'
          );
+         return;
       }
 
       this._serverless.cli.log('Need to subscribe ' + fnDef.name + ' to ' + topicName);
@@ -79,8 +80,10 @@ module.exports = Class.extend({
             var params;
 
             if (info.SubscriptionArn) {
-               return self._serverless.cli.log('Function ' + info.FunctionArn + ' is already subscribed to ' + info.TopicArn);
+               self._serverless.cli.log('Function ' + info.FunctionArn + ' is already subscribed to ' + info.TopicArn);
+               return;
             }
+            self._serverless.cli.log('Got HERE!!!!');
             params = {
                TopicArn: info.TopicArn,
                Protocol: 'lambda',
@@ -88,7 +91,8 @@ module.exports = Class.extend({
             };
             return self._provider.request('SNS', 'subscribe', params, self._opts.stage, self._opts.region)
                .then(function() {
-                  return self._serverless.cli.log('Function ' + info.FunctionArn + ' is now subscribed to ' + info.TopicArn);
+                  self._serverless.cli.log('Function ' + info.FunctionArn + ' is now subscribed to ' + info.TopicArn);
+                  return;
                });
          });
    },

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ module.exports = Class.extend({
 
       this._serverless.cli.log('Need to subscribe ' + fnDef.name + ' to ' + topicName);
 
-      return this._getSubscriptionInfo(fnName, fnDef, topicName)
+      return this._getSubscriptionInfo(fnDef, topicName)
          .then(function(info) {
             if (info.SubscriptionArn) {
                return self._serverless.cli.log('Function ' + info.FunctionArn + ' is already subscribed to ' + info.TopicArn);
@@ -91,7 +91,7 @@ module.exports = Class.extend({
 
       this._serverless.cli.log('Need to unsubscribe ' + fnDef.name + ' from ' + topicName);
 
-      return this._getSubscriptionInfo(fnName, fnDef, topicName)
+      return this._getSubscriptionInfo(fnDef, topicName)
          .then(function(info) {
             if (!info.SubscriptionArn) {
                return self._serverless.cli.log('Function ' + info.FunctionArn + ' is not subscribed to ' + info.TopicArn);
@@ -107,7 +107,7 @@ module.exports = Class.extend({
          });
    },
 
-   _getSubscriptionInfo: function(fnName, fnDef, topicName) {
+   _getSubscriptionInfo: function(fnDef, topicName) {
       var self = this,
           sns = new AWS.SNS(),
           lambda = new AWS.Lambda(),

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,11 @@ module.exports = Class.extend({
 
       this.commands = {
          subscribeExternalSNS: {
+            usage: 'Adds subscriptions to any SNS Topics defined by externalSNS.',
             lifecycleEvents: [ 'subscribe' ],
          },
          unsubscribeExternalSNS: {
+            usage: 'Removes subscriptions to any SNS Topics defined by externalSNS.',
             lifecycleEvents: [ 'unsubscribe' ],
          },
       };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ module.exports = Class.extend({
    init: function(serverless, opts) {
       this._serverless = serverless;
       this._opts = opts;
-      this._provider = serverless ? serverless.getProvider('aws') : null;
+      this.provider = serverless ? serverless.getProvider('aws') : null;
 
       this.hooks = {
          'deploy:compileEvents': this._loopEvents.bind(this, this.addEventPermission),
@@ -83,13 +83,12 @@ module.exports = Class.extend({
                self._serverless.cli.log('Function ' + info.FunctionArn + ' is already subscribed to ' + info.TopicArn);
                return;
             }
-            self._serverless.cli.log('Got HERE!!!!');
             params = {
                TopicArn: info.TopicArn,
                Protocol: 'lambda',
                Endpoint: info.FunctionArn
             };
-            return self._provider.request('SNS', 'subscribe', params, self._opts.stage, self._opts.region)
+            return self.provider.request('SNS', 'subscribe', params, self._opts.stage, self._opts.region)
                .then(function() {
                   self._serverless.cli.log('Function ' + info.FunctionArn + ' is now subscribed to ' + info.TopicArn);
                   return;
@@ -110,7 +109,7 @@ module.exports = Class.extend({
                return self._serverless.cli.log('Function ' + info.FunctionArn + ' is not subscribed to ' + info.TopicArn);
             }
 
-            return self._provider.request('SNS', 'unsubscribe', params, self._opts.stage, self._opts.region)
+            return self.provider.request('SNS', 'unsubscribe', params, self._opts.stage, self._opts.region)
                .then(function() {
                   return self._serverless.cli.log(
                     'Function ' + info.FunctionArn + ' is no longer subscribed to ' + info.TopicArn +
@@ -126,7 +125,7 @@ module.exports = Class.extend({
 
       params = { FunctionName: fnDef.name };
 
-      return this._provider.request('Lambda', 'getFunction', params, this._opts.stage, this._opts.region)
+      return this.provider.request('Lambda', 'getFunction', params, this._opts.stage, this._opts.region)
          .then(function(fn) {
 
             fnArn = fn.Configuration.FunctionArn;
@@ -139,7 +138,7 @@ module.exports = Class.extend({
             self._serverless.cli.log('Topic ARN: ' + topicArn);
 
             // NOTE: does not support NextToken and paginating through subscriptions at this point
-            return self._provider.request('SNS', 'listSubscriptionsByTopic',
+            return self.provider.request('SNS', 'listSubscriptionsByTopic',
               { TopicArn: topicArn }, self._opts.stage, self._opts.region
             );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var _ = require('underscore'),
-    Q = require('q'),
-    AWS = require('aws-sdk'),
     Class = require('class.extend');
 
 module.exports = Class.extend({

--- a/src/index.js
+++ b/src/index.js
@@ -106,15 +106,17 @@ module.exports = Class.extend({
             var params = { SubscriptionArn: info.SubscriptionArn };
 
             if (!info.SubscriptionArn) {
-               return self._serverless.cli.log('Function ' + info.FunctionArn + ' is not subscribed to ' + info.TopicArn);
+               self._serverless.cli.log('Function ' + info.FunctionArn + ' is not subscribed to ' + info.TopicArn);
+               return;
             }
 
             return self.provider.request('SNS', 'unsubscribe', params, self._opts.stage, self._opts.region)
                .then(function() {
-                  return self._serverless.cli.log(
+                  self._serverless.cli.log(
                     'Function ' + info.FunctionArn + ' is no longer subscribed to ' + info.TopicArn +
                     ' (deleted ' + info.SubscriptionArn + ')'
                   );
+                  return;
                });
          });
    },

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ module.exports = Class.extend({
    init: function(serverless, opts) {
       this._serverless = serverless;
       this._opts = opts;
-      this._provider = serverless.getProvider('aws');
+      this._provider = serverless ? serverless.getProvider('aws') : null;
 
       this.hooks = {
          'deploy:compileEvents': this._loopEvents.bind(this, this.addEventPermission),

--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,7 @@ module.exports = Class.extend({
           value, params;
 
       value = {
-         retryPolicy: attribute.value
+         healthyRetryPolicy: attribute.value
       };
 
       params = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
-
 var _ = require('underscore'),
-    Class = require('class.extend');
+    Class = require('class.extend'),
+    DELIVERY_POLICY_ATTR = 'DeliveryPolicy';
 
 module.exports = Class.extend({
 
@@ -44,11 +44,17 @@ module.exports = Class.extend({
    },
 
    addEventPermission: function(fnName, fnDef, topicName) {
-      var normalizedFnName = this._normalize(fnName),
-          normalizedTopicName = this._normalizeTopicName(topicName),
+      var normalizedTopicName, permRef,
+          normalizedFnName = this._normalize(fnName),
           fnRef = normalizedFnName + 'LambdaFunction',
-          permRef = normalizedFnName + 'LambdaPermission' + normalizedTopicName,
           permission;
+
+      if (_.isObject(topicName)) {
+         topicName = topicName.topic;
+      }
+
+      normalizedTopicName = this._normalizeTopicName(topicName);
+      permRef = normalizedFnName + 'LambdaPermission' + normalizedTopicName;
 
       permission = {
          Type: 'AWS::Lambda::Permission',
@@ -64,7 +70,19 @@ module.exports = Class.extend({
    },
 
    subscribeFunction: function(fnName, fnDef, topicName) {
-      var self = this;
+      var self = this,
+          subscriptionAttrs;
+
+      if (_.isObject(topicName)) {
+         if (_.has(topicName, DELIVERY_POLICY_ATTR)) {
+            subscriptionAttrs = {
+               name: DELIVERY_POLICY_ATTR,
+               value: topicName[DELIVERY_POLICY_ATTR]
+            };
+         }
+
+         topicName = topicName.topic;
+      }
 
       if (this._opts.noDeploy) {
          this._serverless.cli.log(
@@ -81,6 +99,10 @@ module.exports = Class.extend({
 
             if (info.SubscriptionArn) {
                self._serverless.cli.log('Function ' + info.FunctionArn + ' is already subscribed to ' + info.TopicArn);
+               if (subscriptionAttrs && info.SubscriptionArn) {
+                  self._serverless.cli.log('Setting subscription attributes');
+                  return self._setSubscriptionAttributes(info.SubscriptionArn, subscriptionAttrs);
+               }
                return;
             }
             params = {
@@ -89,8 +111,12 @@ module.exports = Class.extend({
                Endpoint: info.FunctionArn
             };
             return self.provider.request('SNS', 'subscribe', params, self._opts.stage, self._opts.region)
-               .then(function() {
+               .then(function(response) {
                   self._serverless.cli.log('Function ' + info.FunctionArn + ' is now subscribed to ' + info.TopicArn);
+                  if (subscriptionAttrs && response.SubscriptionArn) {
+                     self._serverless.cli.log('Setting subscription attributes');
+                     return self._setSubscriptionAttributes(response.SubscriptionArn, subscriptionAttrs);
+                  }
                   return;
                });
          });
@@ -99,6 +125,9 @@ module.exports = Class.extend({
    unsubscribeFunction: function(fnName, fnDef, topicName) {
       var self = this;
 
+      if (_.isObject(topicName)) {
+         topicName = topicName.topic;
+      }
       this._serverless.cli.log('Need to unsubscribe ' + fnDef.name + ' from ' + topicName);
 
       return this._getSubscriptionInfo(fnDef, topicName)
@@ -113,8 +142,8 @@ module.exports = Class.extend({
             return self.provider.request('SNS', 'unsubscribe', params, self._opts.stage, self._opts.region)
                .then(function() {
                   self._serverless.cli.log(
-                    'Function ' + info.FunctionArn + ' is no longer subscribed to ' + info.TopicArn +
-                    ' (deleted ' + info.SubscriptionArn + ')'
+                     'Function ' + info.FunctionArn + ' is no longer subscribed to ' + info.TopicArn +
+                     ' (deleted ' + info.SubscriptionArn + ')'
                   );
                   return;
                });
@@ -141,7 +170,7 @@ module.exports = Class.extend({
 
             // NOTE: does not support NextToken and paginating through subscriptions at this point
             return self.provider.request('SNS', 'listSubscriptionsByTopic',
-              { TopicArn: topicArn }, self._opts.stage, self._opts.region
+               { TopicArn: topicArn }, self._opts.stage, self._opts.region
             );
 
          })
@@ -168,6 +197,23 @@ module.exports = Class.extend({
 
    _normalizeTopicName: function(arn) {
       return this._normalize(arn.replace(/[^0-9A-Za-z]/g, ''));
+   },
+
+   _setSubscriptionAttributes: function(subscriptionArn, attribute) {
+      var self = this,
+          value, params;
+
+      value = {
+         retryPolicy: attribute.value
+      };
+
+      params = {
+         AttributeName: attribute.name,
+         SubscriptionArn: subscriptionArn,
+         AttributeValue: JSON.stringify(value)
+      };
+
+      return self.provider.request('SNS', 'setSubscriptionAttributes', params, self._opts.stage, self._opts.region);
    },
 
 });

--- a/src/index.js
+++ b/src/index.js
@@ -91,20 +91,20 @@ module.exports = Class.extend({
    },
 
    unsubscribeFunction: function(fnName, fnDef, topicName) {
-      var self = this,
-          sns = new AWS.SNS();
 
       this._serverless.cli.log('Need to unsubscribe ' + fnDef.name + ' from ' + topicName);
 
       return this._getSubscriptionInfo(fnDef, topicName)
-         .then(function(info) {
+         .then((info) => {
             if (!info.SubscriptionArn) {
                return self._serverless.cli.log('Function ' + info.FunctionArn + ' is not subscribed to ' + info.TopicArn);
             }
 
-            return Q.ninvoke(sns, 'unsubscribe', { SubscriptionArn: info.SubscriptionArn })
-               .then(function() {
-                  return self._serverless.cli.log(
+            return this._provider.request('SNS', 'unsubscribe',
+              { SubscriptionArn: info.SubscriptionArn },
+              this._opts.stage, this._opts.region)
+               .then(() => {
+                  return this._serverless.cli.log(
                      'Function ' + info.FunctionArn + ' is no longer subscribed to ' + info.TopicArn +
                      ' (deleted ' + info.SubscriptionArn + ')'
                   );

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -1,9 +1,9 @@
 'use strict';
-
 var expect = require('expect.js'),
     Plugin = require('../index.js'),
     BbPromise = require('bluebird'),
-    sinon = require('sinon');
+    sinon = require('sinon'),
+    DELIVERY_POLICY_ATTR = 'DeliveryPolicy';
 
 describe('serverless-plugin-external-sns-events', function() {
 
@@ -117,6 +117,51 @@ describe('serverless-plugin-external-sns-events', function() {
 
          expect(actualPerm).to.eql(expPerm);
 
+      });
+
+      it('can handle an object as event args', function() {
+         // ARRANGE:
+
+         var plugin, mockServerless, spyRequestFunc, expPerm, expResourceName,
+             actualPerm,
+             topicName = 'cool-Topic',
+             functionName = 'myFunc';
+
+         mockServerless = createMockServerless(createMockRequest(sinon.stub()));
+         spyRequestFunc = sinon.spy(mockServerless.getProvider('aws'), 'request');
+
+         plugin = new Plugin(mockServerless, { });
+
+
+         // ACT:
+         plugin.addEventPermission(functionName, { name: functionName }, {
+            topic: topicName
+         });
+
+
+         // ASSERT:
+
+         expect(spyRequestFunc.callCount).to.be(0);
+
+         expect(Object.keys(mockServerless.service.provider.compiledCloudFormationTemplate.Resources).length).to.be(1);
+
+         expResourceName = 'MyFuncLambdaPermissionCoolTopic';
+
+         expect(expResourceName in mockServerless.service.provider.compiledCloudFormationTemplate.Resources).to.be(true);
+
+         actualPerm = mockServerless.service.provider.compiledCloudFormationTemplate.Resources[expResourceName];
+
+         expPerm = {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+               FunctionName: { 'Fn::GetAtt': [ 'MyFuncLambdaFunction', 'Arn' ] },
+               Action: 'lambda:InvokeFunction',
+               Principal: 'sns.amazonaws.com',
+               SourceArn: { 'Fn::Join': [ ':', [ 'arn:aws:sns', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, 'cool-Topic' ] ] }
+            },
+         };
+
+         expect(actualPerm).to.eql(expPerm);
       });
 
    });
@@ -366,6 +411,169 @@ describe('serverless-plugin-external-sns-events', function() {
 
       });
 
+      it('an add the subscription attributes on an already existing subscription', function() {
+
+         // ARRANGE:
+         var requestStub, mockServerless, requestMethod, plugin, actual, eventArgs,
+             stubGetSubscriptionInfo, stubSetSubscriptionAttributes, funcDef,
+             stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc';
+
+         eventArgs = {
+            topic: topicName,
+            DeliveryPolicy: {
+               maxDelayTarget: 60,
+               numRetries: 10
+            }
+         };
+
+         requestStub = sinon.stub();
+         mockServerless = createMockServerless(createMockRequest(requestStub));
+         requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request');
+
+         plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: false });
+         stubGetSubscriptionInfo = sinon.stub(plugin, '_getSubscriptionInfo', function() {
+            return BbPromise.resolve({
+               FunctionArn: 'some-func-arn',
+               TopicArn: 'some-topic-arn',
+               SubscriptionArn: 'subscription-arn-here',
+            });
+         });
+
+         stubSetSubscriptionAttributes = sinon.stub(plugin, '_setSubscriptionAttributes', function() {
+            return {
+               ResponseMetadata: {
+                  RequestId: 'some-req-id'
+               }
+            };
+         });
+         funcDef = { name: functionName };
+
+         // ACT:
+         actual = plugin.subscribeFunction(functionName, funcDef, eventArgs);
+
+         // ASSERT:
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function(result) {
+
+            expect(stubGetSubscriptionInfo.callCount).to.be(1);
+            expect(stubGetSubscriptionInfo.calledWithExactly(funcDef, topicName)).to.be(true);
+
+            // Since we mocked getSubscriptionInfo and added a fake SubscriptionArn
+            // then no subsequent requests should have been made to the provider.
+            expect(requestMethod.callCount).to.be(0);
+
+            expect(result).to.eql({
+               ResponseMetadata: {
+                  RequestId: 'some-req-id'
+               }
+            });
+
+            expect(stubSetSubscriptionAttributes.callCount).to.be(1);
+            expect(stubSetSubscriptionAttributes.calledWithExactly('subscription-arn-here', {
+               name: 'DeliveryPolicy',
+               value: {
+                  maxDelayTarget: 60,
+                  numRetries: 10
+               }
+            }));
+
+         });
+
+      });
+
+      it('can add the subscription attributes on a newly created subscription', function() {
+
+         // ARRANGE:
+         var requestStub, mockServerless, requestMethod, plugin, actual, eventArgs,
+             stubGetSubscriptionInfo, stubSetSubscriptionAttributes, funcDef, expSub,
+             stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc';
+
+         eventArgs = {
+            topic: topicName,
+            DeliveryPolicy: {
+               maxDelayTarget: 60,
+               numRetries: 10
+            }
+         };
+         expSub = {
+            TopicArn: 'some-topic-arn',
+            Protocol: 'lambda',
+            Endpoint: 'some-func-arn'
+         };
+
+         requestStub = sinon.stub();
+         requestStub.withArgs('SNS', 'subscribe', expSub, stage, region)
+            .returns(BbPromise.resolve({
+               SubscriptionArn: 'some-sub-arn'
+            }));
+         mockServerless = createMockServerless(createMockRequest(requestStub));
+         requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request');
+
+         plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: false });
+         stubGetSubscriptionInfo = sinon.stub(plugin, '_getSubscriptionInfo', function() {
+            return BbPromise.resolve({
+               FunctionArn: 'some-func-arn',
+               TopicArn: 'some-topic-arn',
+               SubscriptionArn: undefined
+            });
+         });
+         stubSetSubscriptionAttributes = sinon.stub(plugin, '_setSubscriptionAttributes', function() {
+            return {
+               ResponseMetadata: {
+                  RequestId: 'some-req-id'
+               }
+            };
+         });
+         funcDef = { name: functionName };
+
+         // ACT:
+         actual = plugin.subscribeFunction(functionName, funcDef, eventArgs);
+
+         // ASSERT:
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function(result) {
+
+            expect(stubGetSubscriptionInfo.callCount).to.be(1);
+            expect(stubGetSubscriptionInfo.calledWithExactly(funcDef, topicName)).to.be(true);
+
+            // Since we mocked getSubscriptionInfo then we will only expect
+            // a single call to request, that is to add the subscription.
+            expect(requestMethod.callCount).to.be(1);
+
+            expect(requestMethod.calledWithExactly('SNS', 'subscribe', expSub, stage, region))
+               .to
+               .be(true);
+
+
+            expect(result).to.eql({
+               ResponseMetadata: {
+                  RequestId: 'some-req-id'
+               }
+            });
+
+            expect(stubSetSubscriptionAttributes.callCount).to.be(1);
+            expect(stubSetSubscriptionAttributes.calledWithExactly('some-sub-arn', {
+               name: 'DeliveryPolicy',
+               value: {
+                  maxDelayTarget: 60,
+                  numRetries: 10
+               }
+            }));
+
+         });
+
+      });
+
    });
 
    describe('unsubscribeFunction', function() {
@@ -470,6 +678,62 @@ describe('serverless-plugin-external-sns-events', function() {
 
       });
 
+      it('can handle an object as event args', function() {
+
+         // ARRANGE:
+         var requestStub, mockServerless, plugin, actual, requestMethod,
+             stubGetSubscriptionInfo, funcDef, params,
+             stage = 'test1',
+             region = 'us-west-42',
+             topicName = 'cooltopic',
+             functionName = 'myFunc';
+
+         requestStub = sinon.stub();
+         mockServerless = createMockServerless(createMockRequest(requestStub));
+         requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request');
+
+         plugin = new Plugin(mockServerless, { stage: stage, region: region, noDeploy: false });
+         stubGetSubscriptionInfo = sinon.stub(plugin, '_getSubscriptionInfo', function() {
+            return BbPromise.resolve({
+               FunctionArn: 'some-func-arn',
+               TopicArn: 'some-topic-arn',
+               SubscriptionArn: 'some-subscription-arn'
+            });
+         });
+         funcDef = { name: functionName };
+
+
+         // ACT:
+         actual = plugin.unsubscribeFunction(functionName, funcDef, {
+            topic: topicName
+         });
+
+
+         // ASSERT:
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function() {
+
+            expect(stubGetSubscriptionInfo.callCount).to.be(1);
+            expect(stubGetSubscriptionInfo.calledWithExactly(funcDef, topicName)).to.be(true);
+
+            // Since we mocked getSubscriptionInfo we should
+            // only have one call to the request (to remove the subscription)
+            expect(requestMethod.callCount).to.be(1);
+
+            params = {
+               SubscriptionArn: 'some-subscription-arn'
+            };
+
+            expect(requestMethod.calledWithExactly('SNS', 'unsubscribe', params, stage, region))
+               .to
+               .be(true);
+
+         });
+
+
+      });
+
    });
 
    describe('_normalize', function() {
@@ -502,6 +766,66 @@ describe('serverless-plugin-external-sns-events', function() {
             .eql('Footopic');
       });
 
+   });
+
+   describe('_setSubscriptionAttributes', function() {
+
+      it('sets DeliveryPolicy attribute', function() {
+         // ARRANGE:
+         var mockServerless, requestMethod, actual, requestStub, plugin, subscriptionArn, attributeValue,
+             requestMethodArgs, requestMethodParamArg,
+             account = '12349',
+             topicName = 'cooltopic',
+             stage = 'test1',
+             region = 'us-west-42';
+
+         attributeValue = {
+            minDelayTarget: 60,
+            maxDelayTarget: 120,
+            numRetries: 5,
+            backoffFunction: 'linear'
+         };
+
+         subscriptionArn = 'arn:aws:sns:' + region + ':' + account + ':' + topicName + ':some-guid';
+
+         requestStub = sinon.stub();
+
+         requestStub.returns({
+            ResponseMetadata: {
+               RequestId: 'some-req-id'
+            }
+         });
+
+         mockServerless = createMockServerless(createMockRequest(requestStub));
+
+         requestMethod = sinon.spy(mockServerless.getProvider('aws'), 'request');
+
+         plugin = new Plugin(mockServerless, { stage: stage, region: region });
+
+
+         // ACT:
+         actual = plugin._setSubscriptionAttributes(subscriptionArn, {
+            name: DELIVERY_POLICY_ATTR,
+            value: attributeValue
+         });
+
+
+         // ASSERT:
+
+         expect(isPromise(actual)).to.be(true);
+
+         return actual.then(function() {
+            expect(requestMethod.callCount).to.be(1);
+            requestMethodArgs = requestMethod.getCall(0).args;
+            expect(requestMethodArgs[0]).to.be('SNS');
+            expect(requestMethodArgs[1]).to.be('setSubscriptionAttributes');
+            expect(requestMethodArgs[2].AttributeName).to.be(DELIVERY_POLICY_ATTR);
+            expect(requestMethodArgs[2].SubscriptionArn).to.be(subscriptionArn);
+
+            requestMethodParamArg = JSON.parse(requestMethodArgs[2].AttributeValue);
+            expect(requestMethodParamArg.retryPolicy).to.eql(attributeValue);
+         });
+      });
    });
 
 });

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -823,7 +823,7 @@ describe('serverless-plugin-external-sns-events', function() {
             expect(requestMethodArgs[2].SubscriptionArn).to.be(subscriptionArn);
 
             requestMethodParamArg = JSON.parse(requestMethodArgs[2].AttributeValue);
-            expect(requestMethodParamArg.retryPolicy).to.eql(attributeValue);
+            expect(requestMethodParamArg.healthyRetryPolicy).to.eql(attributeValue);
          });
       });
    });

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -289,7 +289,7 @@ describe('serverless-plugin-external-sns-events', function() {
          // ASSERT:
 
          expect(isPromise(actual)).to.be(true);
-         
+
          return actual.then(function(result) {
 
             expect(stubGetSubscriptionInfo.callCount).to.be(1);


### PR DESCRIPTION
AWS allows you set the DeliveryPolicy on a per subscription basis, and I needed this, so I figured someone else might. More info can be found here: http://docs.aws.amazon.com/sns/latest/api/API_SetSubscriptionAttributes.html

Let me know if you'd like any changes.